### PR TITLE
build: OpenTofuからTerraformへの移行

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "tofu init".
+# This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.opentofu.org/cloudflare/cloudflare" {
+provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "4.52.1"
   constraints = "~> 4.0"
   hashes = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ncaq.net Cloudflare Infrastructure as Code
 
-このリポジトリはCloudflareのインフラストラクチャをOpenTofuで管理するための設定です。
+このリポジトリはCloudflareのインフラストラクチャをTerraformで管理するための設定です。
 
 ## セットアップ
 
@@ -39,20 +39,20 @@ API TokenはGitからignoreされている`.env.local`に書き込んでdirenv�
 ### 変更の確認
 
 ```bash
-tofu plan
+terraform plan
 ```
 
 ### 変更の適用
 
 ```bash
-tofu apply
+terraform apply
 ```
 
 ### 状態の確認
 
 ```bash
-tofu state list
-tofu state show <resource_name>
+terraform state list
+terraform state show <resource_name>
 ```
 
 ## 注意事項

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,12 @@
           config,
           ...
         }:
+        let
+          pkgsWithUnfree = import inputs.nixpkgs {
+            system = pkgs.system;
+            config.allowUnfree = true;
+          };
+        in
         {
           treefmt.config = {
             projectRootFile = "flake.nix";
@@ -45,8 +51,8 @@
             };
           };
           devShells.default = pkgs.mkShell {
-            buildInputs = with pkgs; [
-              opentofu # 深い意図はない。unfree警告を外すのが面倒で、まだterraform固有の機能が必要では無かっただけ。
+            buildInputs = with pkgsWithUnfree; [
+              terraform
               terraform-docs
               terraform-ls
               tflint


### PR DESCRIPTION
- .terraform.lock.hclのprovider参照をOpenTofuからTerraformに変更
- README.mdの説明・コマンド例をTerraformに統一
- flake.nixのdevShellsでopentofuからterraformへ切り替え
- unfreeパッケージ許可設定を追加
