### PR TITLE
feat(cloudflare): SSH用DNSレコードをTailscale経由に変更

### DIFF
--- a/cloudflare/forgejo.tf
+++ b/cloudflare/forgejo.tf
@@ -8,14 +8,16 @@ resource "cloudflare_dns_record" "forgejo" {
 }
 
 # ssh接続でcloneやpushを行うためのアクセスポイントです。
-# 無料版のCloudflare Zero Trust Tunnelのhttpsでの一回での通信では転送量制限が厳しいのでsshに逃げられるようにしています。
-# 無料版のCloudflare Zero Trust Tunnelの制約上`ssh.forgejo.ncaq.net`とするとTLSの解決ができないため、
-# `forgejo-ssh.ncaq.net`で妥協しています。
+# 無料版のCloudflare Zero Trust Tunnelのhttpsでの一回での通信では転送量制限が厳しいのでsshで接続できるようにしています。
+# Tailscale経由でのみアクセス可能です。
+# CNAMEでseminar.border-saurolophus.ts.netを参照したかったのですが、
+# Tailscale MagicDNSがCNAMEチェーンを追跡しないため、
+# ひとまずAレコードで直接指定しています。
 resource "cloudflare_dns_record" "forgejo-ssh" {
   zone_id = var.zone_id
-  name    = "forgejo-ssh.ncaq.net"
-  type    = "CNAME"
-  content = "${cloudflare_zero_trust_tunnel_cloudflared.seminar.id}.cfargotunnel.com"
-  proxied = true
+  name    = "ssh.forgejo.ncaq.net"
+  type    = "A"
+  content = "100.82.4.93"
+  proxied = false # sshなのでfalse。TailscaleのIPアドレスは公開しても問題ない。
   ttl     = 1
 }

--- a/cloudflare/seminar.tf
+++ b/cloudflare/seminar.tf
@@ -9,12 +9,3 @@ resource "random_password" "seminar" {
   length  = 63
   special = false
 }
-
-resource "cloudflare_dns_record" "seminar-ssh" {
-  zone_id = var.zone_id
-  name    = "seminar-ssh.ncaq.net"
-  type    = "CNAME"
-  content = "${cloudflare_zero_trust_tunnel_cloudflared.seminar.id}.cfargotunnel.com"
-  proxied = true
-  ttl     = 1
-}


### PR DESCRIPTION
ssh接続はTailscaleのDNSが使えることを前提にします。
これによりTailscaleに侵入されて、
さらにSSH秘密鍵が漏洩するかsshサーバの脆弱性がない限り侵入は困難になります。
両方に問題が発生する可能性は少ないので、
少し安全になると考えています。
