### PR TITLE
feat(seminar): atticdエンドポイントをTailscaleに切り替え

### DIFF
--- a/cloudflare/nix-cache.tf
+++ b/cloudflare/nix-cache.tf
@@ -1,6 +1,6 @@
 # Tailnet内部からのみアクセス可能なatticバイナリキャッシュ。
 # Tailscale IPは公開しても問題ないため`proxied = false`。
-resource "cloudflare_dns_record" "cache_nix_a" {
+resource "cloudflare_dns_record" "cache_nix_v4" {
   zone_id = var.zone_id
   name    = "cache.nix.ncaq.net"
   type    = "A"
@@ -9,7 +9,7 @@ resource "cloudflare_dns_record" "cache_nix_a" {
   ttl     = 1
 }
 
-resource "cloudflare_dns_record" "cache_nix_aaaa" {
+resource "cloudflare_dns_record" "cache_nix_v6" {
   zone_id = var.zone_id
   name    = "cache.nix.ncaq.net"
   type    = "AAAA"


### PR DESCRIPTION
Cloudflare Tunnelは一回のリクエストでのサイズ制限が厳しいため。
