### PR TITLE
feat(cloudflare): mcp-proxy用DNSレコードのTerraform定義を追加

### DIFF
--- a/cloudflare/mcp-proxy.tf
+++ b/cloudflare/mcp-proxy.tf
@@ -1,0 +1,19 @@
+# Tailnet内部からのみアクセス可能なmcp-nixos HTTPプロキシ。
+# Tailscale IPは公開しても問題ないため`proxied = false`。
+resource "cloudflare_dns_record" "mcp_proxy_v4" {
+  zone_id = var.zone_id
+  name    = "mcp-proxy.ncaq.net"
+  type    = "A"
+  content = var.seminar_tailscale_ipv4
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "mcp_proxy_v6" {
+  zone_id = var.zone_id
+  name    = "mcp-proxy.ncaq.net"
+  type    = "AAAA"
+  content = var.seminar_tailscale_ipv6
+  proxied = false
+  ttl     = 1
+}


### PR DESCRIPTION
- Tailnet内部専用HTTPプロキシのA/AAAAレコードを新規作成
- Tailscale IP公開のためproxied=falseを指定
- TTLはCloudflareの自動設定(1)を利用
