### PR TITLE
fix(acl): seminarをexit nodeとして選択できるように

### DIFF
--- a/tailscale/acl.tf
+++ b/tailscale/acl.tf
@@ -26,7 +26,16 @@ resource "tailscale_acl" "this" {
         dst = ["autogroup:member"],
         ip  = ["*"],
       },
+      {
+        src = ["autogroup:member"],
+        dst = ["autogroup:internet"],
+        ip  = ["*"],
+      },
     ],
+    # 指定されたタグ付きのデバイスもexit nodeとしては自動承認します。
+    autoApprovers = {
+      exitNode = ["tag:server"],
+    },
     ssh = [
       {
         action = "check",


### PR DESCRIPTION
- exit nodeとしてtag:serverが付与されたデバイスを自動承認する設定を追加
- autogroup:memberからautogroup:internetへのルールを新規追加
