### PR TITLE
fix: ロックファイル更新後に壊れた`allowlistedLicenses`参照を修正

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1777673416,
+        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
 
       perSystem =
         {
-          lib,
           system,
           ...
         }:
@@ -31,7 +30,7 @@
           pkgs = import inputs.nixpkgs {
             inherit system;
             config = {
-              allowlistedLicenses = with lib.licenses; [
+              allowlistedLicenses = with inputs.nixpkgs.lib.licenses; [
                 bsl11 # Terraformを使うので許可します。個人的にもAGPLがフリーでbsl11がフリーじゃないのはあまり納得感がない。
               ];
             };


### PR DESCRIPTION
renovateによる`flake.lock`更新と、
それに伴って必要となった`flake.nix`側の修正をまとめて取り込みます。

`flake-parts`の`perSystem`が注入する`lib`は`flake-parts`自身の`nixpkgs-lib`入力に由来し、
`nixpkgs`本体とはバージョンが分離しています。
今回のロックファイル更新で`flake-parts/nixpkgs-lib`側だけが先行し、
`lib.licenses.bsl11`に`licenseType = "simple"`属性が追加されました。
一方、`nixpkgs`本体の`bsl11`にはまだその属性が無いため、
`check-meta.nix`の`elem`による属性集合の完全一致判定が失敗し、
`terraform`が許可リストに含まれない判定となって`direnv allow`が通らなくなっていました。

`inputs.nixpkgs.lib.licenses`から直接参照することで`pkgs.terraform.meta.license`と
同一の属性集合を渡せるようになり、上流のバージョンずれの影響を受けなくなります。
