### PR TITLE
feat: ファイルシステム使用率の監視ルールを追加

### DIFF
--- a/mackerel/monitor.tf
+++ b/mackerel/monitor.tf
@@ -5,3 +5,17 @@ resource "mackerel_monitor" "connectivity" {
     alert_status_on_gone = "CRITICAL"
   }
 }
+
+resource "mackerel_monitor" "filesystem" {
+  name = "filesystem"
+
+  # disk%はMackerelの「ファイルシステム使用率」専用メトリック種別で、
+  # ホスト上の全ファイルシステムのうち使用率が最も高いものを閾値と比較する。
+  # 空き領域が1割を切る = 使用率が90%を超えることを異常扱いとする。
+  host_metric {
+    metric   = "disk%"
+    operator = ">"
+    critical = 90
+    duration = 3
+  }
+}


### PR DESCRIPTION
ホスト上のファイルシステムの空き領域が1割を切った場合に異常として検知できるようにします。

Mackerelの`disk%`メトリックは「ファイルシステム使用率」専用の特殊な種別で、
ホスト上の複数ファイルシステムのうち使用率が最も高いものを閾値と比較します。
サービスやロールの登録なしでもそのまま機能するため、
現状のシンプルな構成に適しています。

一時的なゆらぎでの誤検知を避けるため、
`duration`は3分としています。
