### PR TITLE
build(deps): update ncaq/nix-composite-action to v3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,9 +24,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: ncaq/nix-composite-action@5a61f70ad5b7d2f276732e14355b7fb2ddd4caaf # v1.3.0
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: ncaq/nix-composite-action@9b26867355388b589de67c08de87e8786e2e8094 # v3.0.0
       - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
 
   terraform-validate:
@@ -40,7 +38,5 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: ncaq/nix-composite-action@5a61f70ad5b7d2f276732e14355b7fb2ddd4caaf # v1.3.0
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: ncaq/nix-composite-action@9b26867355388b589de67c08de87e8786e2e8094 # v3.0.0
       - run: nix run '.#terraform-validate'


### PR DESCRIPTION
ncaq/nix-composite-actionのv3で`cachix-auth-token`入力が削除され、
Cachixはread-only substituterとしてのみ追加されるようになりました。
書き込みはniks3に一本化されています。

これに伴い、呼び出し側で`cachix-auth-token`を渡している箇所を削除し、
バージョン参照をv3へ更新します。

ref https://github.com/ncaq/nix-composite-action/pull/67
