### PR TITLE
revert: mcp-nixosのfaviconリダイレクトrulesetを削除

### DIFF
--- a/cloudflare/mcp-nixos.tf
+++ b/cloudflare/mcp-nixos.tf
@@ -6,31 +6,3 @@ resource "cloudflare_dns_record" "mcp-nixos" {
   proxied = true
   ttl     = 1
 }
-
-# mcp-nixos subdomainのfaviconをmcp-nixosリポジトリのものにリダイレクトします。
-# fastmcpはfaviconを提供しないため、ブラウザがncaq.netのfaviconにフォールバックしてしまうのを防ぎます。
-resource "cloudflare_ruleset" "mcp-nixos_redirect" {
-  zone_id = var.zone_id
-  name    = "mcp-nixos redirects"
-  kind    = "zone"
-  phase   = "http_request_dynamic_redirect"
-
-  rules = [
-    {
-      action      = "redirect"
-      description = "Redirect favicon.ico to mcp-nixos repository favicon"
-      enabled     = true
-      expression  = "(http.host eq \"mcp-nixos.ncaq.net\" and http.request.uri.path eq \"/favicon.ico\")"
-
-      action_parameters = {
-        from_value = {
-          status_code = 302
-          target_url = {
-            value = "https://raw.githubusercontent.com/utensils/mcp-nixos/main/website/public/favicon/favicon.ico"
-          }
-          preserve_query_string = false
-        }
-      }
-    }
-  ]
-}


### PR DESCRIPTION
MCPクライアントが使うfaviconリゾルバ(Google s2など)は、
クロスホストへの302リダイレクトを追跡しないため、
このリダイレクトではfaviconを認識させられませんでした。
サブドメインにfaviconが無いと判定されると、
親ドメインのfaviconにフォールバックするため、
結局本体サイトのfaviconが表示されてしまっていました。

代わりにorigin(seminarのmicrovm内のCaddy)が、
`/favicon.ico`を200で直接配信する方式に移行します。
edge側で302を返し続けるとoriginにリクエストが届かないので、
このrulesetの削除が必須です。

see `e657d337d8eadbf8effd9b60b7bde0e4b89635ab`

origin側の対応はdotfilesのPRで行います。
ref https://github.com/ncaq/dotfiles/pull/1306