### PR TITLE
feat: cdn.ncaq.netをPagesからseminarのTunnel配信へ切り替え

### DIFF
--- a/cloudflare/cdn.tf
+++ b/cloudflare/cdn.tf
@@ -1,0 +1,11 @@
+# cdn.ncaq.netはseminarからCloudflare Tunnel経由で配信しています。
+# Pagesには1ファイル25MiBの制限があり配信できないファイルがあるため移行しました。
+# 配信設定はdotfilesのnixos/host/seminar/cdn.nixにあります。
+resource "cloudflare_dns_record" "cdn" {
+  zone_id = var.zone_id
+  name    = "cdn.ncaq.net"
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.seminar.id}.cfargotunnel.com"
+  proxied = true
+  ttl     = 1
+}

--- a/cloudflare/dns.tf
+++ b/cloudflare/dns.tf
@@ -1,12 +1,3 @@
-resource "cloudflare_dns_record" "cdn" {
-  zone_id = var.zone_id
-  name    = "cdn.ncaq.net"
-  type    = "CNAME"
-  content = "cdn-ncaq-net.pages.dev"
-  proxied = true
-  ttl     = 1
-}
-
 resource "cloudflare_dns_record" "root" {
   zone_id = var.zone_id
   name    = "ncaq.net"

--- a/cloudflare/pages.tf
+++ b/cloudflare/pages.tf
@@ -25,35 +25,6 @@ resource "cloudflare_pages_domain" "ncaq_net_apex" {
   name         = "ncaq.net"
 }
 
-resource "cloudflare_pages_project" "cdn_ncaq_net" {
-  account_id        = var.account_id
-  name              = "cdn-ncaq-net"
-  production_branch = "master"
-
-  source = {
-    type = "github"
-    config = {
-      owner     = "ncaq"
-      repo_name = "cdn.ncaq.net"
-    }
-  }
-
-  deployment_configs = {
-    preview = {
-      build_image_major_version = 3
-    }
-    production = {
-      build_image_major_version = 3
-    }
-  }
-}
-
-resource "cloudflare_pages_domain" "cdn_ncaq_net_cdn" {
-  account_id   = var.account_id
-  project_name = cloudflare_pages_project.cdn_ncaq_net.name
-  name         = "cdn.ncaq.net"
-}
-
 resource "cloudflare_pages_project" "www_ncaq_net" {
   account_id        = var.account_id
   name              = "www-ncaq-net"


### PR DESCRIPTION
Cloudflare Pagesには1ファイル25MiBの制限があり配信できないファイルがあるため、
自宅サーバseminarからCloudflare Tunnel経由で配信する方式に移行します。

DNSレコードをPagesへのCNAMEからseminarトンネルへのCNAMEに変更して、
forgejoなど他のTunnelサービスと同じく個別ファイル`cdn.tf`に移動します。
不要になったPagesプロジェクトとカスタムドメインは削除します。

`page_rules.tf`のCache Everythingルールは配信元が変わっても有効なので、
そのまま残します。

サーバ側の配信設定はdotfilesの`nixos/host/seminar/cdn.nix`にあります。
