### PR TITLE
feat: ComfyUIをTailscale Serviceとして公開

### DIFF
--- a/tailscale/acl.tf
+++ b/tailscale/acl.tf
@@ -1,4 +1,6 @@
 resource "tailscale_acl" "this" {
+  depends_on = [tailscale_service.comfyui]
+
   acl = jsonencode({
     tagOwners = {
       # サーバをautogroupから剥がすことで`tailscale ssh`アクセスを禁止します。
@@ -8,33 +10,44 @@ resource "tailscale_acl" "this" {
       # Tailscaleだけでssh出来てしまうと意味がないからです。
       # クライアントが一時的に立ち上げる場合パスワード認証よりはマシなので、
       # 全体的には禁止しません。
-      "tag:server" = ["tag:server", "autogroup:admin"],
+      "tag:server" = ["autogroup:admin", "tag:server"],
+      # Terraformで使用するdotfiles-sops OAuthクライアントにはtag:serverが設定されているため、
+      # そのクライアントからtag:comfyuiを付与できるようにします。
+      "tag:comfyui" = ["autogroup:admin", "tag:server"],
     },
     grants = [
+      # タグを付与すると端末はautogroup:memberから外れるため、
+      # タグ付与前のautogroup:memberと同じIPアクセスを維持します。
       {
         src = ["autogroup:member"],
-        dst = ["autogroup:member"],
-        ip  = ["*"],
-      },
-      {
-        src = ["autogroup:member"],
-        dst = ["tag:server"],
+        dst = ["autogroup:member", "autogroup:internet", "tag:server", "tag:comfyui"],
         ip  = ["*"],
       },
       {
         src = ["tag:server"],
-        dst = ["autogroup:member"],
+        dst = ["autogroup:member", "tag:comfyui"],
         ip  = ["*"],
       },
       {
-        src = ["autogroup:member"],
-        dst = ["autogroup:internet"],
+        src = ["tag:comfyui"],
+        dst = ["autogroup:member", "autogroup:internet", "tag:server"],
         ip  = ["*"],
+      },
+      # tailnetのユーザー所有端末とServiceホスト自身から、
+      # ComfyUIのHTTPS endpointだけへアクセスを許可します。
+      {
+        src = ["autogroup:member", "tag:server", "tag:comfyui"],
+        dst = ["svc:comfyui"],
+        ip  = ["tcp:443"],
       },
     ],
     # 指定されたタグ付きのデバイスもexit nodeとしては自動承認します。
     autoApprovers = {
       exitNode = ["tag:server"],
+      # tag:comfyuiを持つ端末からのService広告を自動承認します。
+      services = {
+        "svc:comfyui" = ["tag:comfyui"]
+      }
     },
     # serverがfunnelを使えるようにします。
     nodeAttrs = [
@@ -49,7 +62,7 @@ resource "tailscale_acl" "this" {
         src    = ["autogroup:member"],
         dst    = ["autogroup:self"],
         users  = ["autogroup:nonroot"],
-      },
+      }
     ],
   })
 }

--- a/tailscale/comfyui.tf
+++ b/tailscale/comfyui.tf
@@ -1,0 +1,12 @@
+# bulletをComfyUI Service専用のホストとして識別します。
+resource "tailscale_device_tags" "bullet" {
+  device_id  = data.tailscale_device.this["bullet"].id
+  tags       = ["tag:comfyui"]
+  depends_on = [tailscale_acl.this]
+}
+
+# ComfyUIへ割り当てる安定したMagicDNS名とTailVIPを作成します。
+resource "tailscale_service" "comfyui" {
+  name  = "svc:comfyui"
+  ports = ["tcp:443"]
+}


### PR DESCRIPTION
bulletに専用タグを付与し、
安定したMagicDNS名でComfyUIへアクセスできるようにします。
タグ付与前のアクセス権を維持しながら、
tailnet端末からHTTPS endpointへの接続を許可します。
