### PR TITLE
feat(tailscale): Open WebUIをseminarへ集約しOllama対象ホストを整理

### DIFF
--- a/tailscale/access-policy.tf
+++ b/tailscale/access-policy.tf
@@ -72,14 +72,14 @@ resource "tailscale_acl" "this" {
         dst = ["svc:comfyui"],
         ip  = ["tcp:443"],
       },
-      # tailnet内の端末から各ホストのOpen WebUI HTTPS endpointへアクセスを許可します。
+      # tailnet内の端末からOpen WebUIのHTTPS endpointへアクセスを許可します。
       {
         src = concat([
           "autogroup:member",
           "tag:server",
           "tag:comfyui",
         ], local.ollama_tags),
-        dst = local.open_webui_services,
+        dst = [tailscale_service.open_webui.name],
         ip  = ["tcp:443"],
       },
       # tailnet内の端末から各ホストのOllama HTTPS endpointへアクセスを許可します。
@@ -100,7 +100,7 @@ resource "tailscale_acl" "this" {
       services = merge(
         { "svc:comfyui" = ["tag:comfyui"] },
         { for host in local.ollama_hosts : "svc:ollama-${host}" => ["tag:ollama-${host}"] },
-        { for host in local.ollama_hosts : "svc:open-webui-${host}" => ["tag:ollama-${host}"] }
+        { (tailscale_service.open_webui.name) = ["tag:ollama-${local.open_webui_host}"] }
       )
     },
     # serverがfunnelを使えるようにします。

--- a/tailscale/device-tag.tf
+++ b/tailscale/device-tag.tf
@@ -4,12 +4,6 @@ resource "tailscale_device_tags" "bullet" {
   depends_on = [tailscale_acl.this]
 }
 
-resource "tailscale_device_tags" "creep" {
-  device_id  = data.tailscale_device.this["creep"].id
-  tags       = ["tag:ollama-creep"]
-  depends_on = [tailscale_acl.this]
-}
-
 resource "tailscale_device_tags" "seminar" {
   device_id  = data.tailscale_device.this["seminar"].id
   tags       = ["tag:server", "tag:ollama-seminar"]

--- a/tailscale/service.tf
+++ b/tailscale/service.tf
@@ -3,9 +3,10 @@ locals {
     "bullet",
     "seminar",
   ])
-  ollama_tags         = [for host in local.ollama_hosts : "tag:ollama-${host}"]
-  ollama_services     = [for host in local.ollama_hosts : "svc:ollama-${host}"]
-  open_webui_services = [for host in local.ollama_hosts : "svc:open-webui-${host}"]
+  ollama_tags     = [for host in local.ollama_hosts : "tag:ollama-${host}"]
+  ollama_services = [for host in local.ollama_hosts : "svc:ollama-${host}"]
+  # Open WebUIはチャット履歴を1箇所へまとめるため常時起動のseminarだけで動かします。
+  open_webui_host = "seminar"
 }
 
 # ComfyUIへ安定したMagicDNS名とTailVIPを割り当てます。
@@ -22,10 +23,10 @@ resource "tailscale_service" "ollama" {
   ports = ["tcp:443"]
 }
 
-# 各ホストのOpen WebUIへ安定したMagicDNS名とTailVIPを割り当てます。
+# Open WebUIへ安定したMagicDNS名とTailVIPを割り当てます。
+# 推論はOpen WebUI側でbulletのOllamaへ優先的に振り分けるため、
+# UIを公開するホストが変わってもここは1つで足ります。
 resource "tailscale_service" "open_webui" {
-  for_each = local.ollama_hosts
-
-  name  = "svc:open-webui-${each.key}"
+  name  = "svc:open-webui"
   ports = ["tcp:443"]
 }

--- a/tailscale/service.tf
+++ b/tailscale/service.tf
@@ -1,7 +1,6 @@
 locals {
   ollama_hosts = toset([
     "bullet",
-    "creep",
     "seminar",
   ])
   ollama_tags         = [for host in local.ollama_hosts : "tag:ollama-${host}"]


### PR DESCRIPTION
Open WebUIのチャット履歴を1箇所へまとめるため、
ホストごとに分かれていたServiceを常時起動のseminarだけで動かす1つのServiceへ統合します。
推論の速いbulletは、Open WebUI側でbulletのOllamaへ優先的に振り分けることで引き続き使えます。

あわせてOllamaの導入先をbulletとseminarに限定したことに合わせて、
`ollama_hosts`からcreepを外し、creep向けのタグとServiceを削除します。
ラップトップのcreepでローカル推論を動かすより、
常時起動でメモリにも余裕があるseminarへ寄せた方がよいという判断です。