### PR TITLE
feat(tailscale): ServiceでHTTPの80番も受け付けます

### DIFF
--- a/tailscale/access-policy.tf
+++ b/tailscale/access-policy.tf
@@ -55,7 +55,9 @@ resource "tailscale_acl" "this" {
         ip = ["*"],
       },
       # tailnetのユーザー所有端末とServiceホスト自身から、
-      # ComfyUIのHTTPS endpointだけへアクセスを許可します。
+      # ComfyUIのendpointだけへアクセスを許可します。
+      # 許可するポートはServiceが公開するポートに揃えます。
+      # HTTPの80番はHTTPSへリダイレクトを返すだけです。
       {
         src = concat([
           "autogroup:member",
@@ -63,9 +65,9 @@ resource "tailscale_acl" "this" {
           "tag:comfyui",
         ], local.ollama_tags),
         dst = ["svc:comfyui"],
-        ip  = ["tcp:443"],
+        ip  = local.service_ports,
       },
-      # tailnet内の端末からOpen WebUIのHTTPS endpointへアクセスを許可します。
+      # tailnet内の端末からOpen WebUIのendpointへアクセスを許可します。
       {
         src = concat([
           "autogroup:member",
@@ -73,9 +75,9 @@ resource "tailscale_acl" "this" {
           "tag:comfyui",
         ], local.ollama_tags),
         dst = [tailscale_service.open_webui.name],
-        ip  = ["tcp:443"],
+        ip  = local.service_ports,
       },
-      # tailnet内の端末から各ホストのOllama HTTPS endpointへアクセスを許可します。
+      # tailnet内の端末から各ホストのOllama endpointへアクセスを許可します。
       {
         src = concat([
           "autogroup:member",
@@ -83,7 +85,7 @@ resource "tailscale_acl" "this" {
           "tag:comfyui",
         ], local.ollama_tags),
         dst = local.ollama_services,
-        ip  = ["tcp:443"],
+        ip  = local.service_ports,
       },
     ],
     # 指定されたタグ付きのデバイスもexit nodeとしては自動承認します。

--- a/tailscale/service.tf
+++ b/tailscale/service.tf
@@ -1,4 +1,10 @@
 locals {
+  # ServiceがHTTPSに加えてHTTPも受け付けるようにします。
+  # 80番はdotfilesの`nixos/tailscale-serve/http-redirect.nix`のCaddyへ繋がり、
+  # HTTPSへリダイレクトを返すだけで中身は何も出しません。
+  # 閉じたままだと`http://`で飛んできた時にTCP接続ごと拒否されて、
+  # URL補完から辿り着けません。
+  service_ports = ["tcp:80", "tcp:443"]
   ollama_hosts = toset([
     "bullet",
     "seminar",
@@ -12,7 +18,7 @@ locals {
 # ComfyUIへ安定したMagicDNS名とTailVIPを割り当てます。
 resource "tailscale_service" "comfyui" {
   name  = "svc:comfyui"
-  ports = ["tcp:443"]
+  ports = local.service_ports
 }
 
 # 各ホストのOllamaへ安定したMagicDNS名とTailVIPを割り当てます。
@@ -20,7 +26,7 @@ resource "tailscale_service" "ollama" {
   for_each = local.ollama_hosts
 
   name  = "svc:ollama-${each.key}"
-  ports = ["tcp:443"]
+  ports = local.service_ports
 }
 
 # Open WebUIへ安定したMagicDNS名とTailVIPを割り当てます。
@@ -28,5 +34,5 @@ resource "tailscale_service" "ollama" {
 # UIを公開するホストが変わってもここは1つで足ります。
 resource "tailscale_service" "open_webui" {
   name  = "svc:open-webui"
-  ports = ["tcp:443"]
+  ports = local.service_ports
 }


### PR DESCRIPTION
Serviceが443番しか公開していないと、
`http://`で飛んできたアクセスがTCP接続ごと拒否されて到達できません。
ブラウザのURL補完はスキームなしの入力からまず`http://`を試すことが多く、
公開しているURLへ辿り着けない場面が頻発していました。

80番の転送先はdotfilesの`nixos/tailscale-serve/http-redirect.nix`のCaddyで、
HTTPSへ308のリダイレクトを返すだけです。
中身は何も出さないので、
80番を開けても公開範囲は広がりません。

ポートの一覧は`local.service_ports`にまとめます。
Serviceの`ports`とgrantの`ip`は揃っていないと、
接続できるはずのポートがACLで落ちるという食い違いが起きるためです。

利用する側の変更はhttps://github.com/ncaq/dotfiles/pull/1484 です。
このPRの内容は既にapply済みで、
bullet上で308のリダイレクトが返ることを確認しています。