### PR TITLE
build: devShellから`nil`を削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,6 @@
               zizmor
 
               # nixの関連ツール。
-              nil
               nix-fast-build
 
               # GitHub関連ツール。


### PR DESCRIPTION
NixのLSPとして`nil`と`nixd`のどちらを使うかはホスト環境に任せるため、
devShellから`nil`を削除しました。
セットアップは複雑ではなくプロジェクトのバージョンにも依存しないため、
プロジェクト側で実装を固定する必要はありません。

ref https://github.com/ncaq/nix-templates/pull/291